### PR TITLE
Ps/Fix c-periphery lib loading crash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ the creator of the icon - for further details see the AboutTab with an automated
 * Used colors looks on your device perhaps a little strange. This demo was tested on a small external 
 touch screen with a limited color dynamic. The used colors are result of this restriction.
 
-**Known errors:**
-Demo crashes in hardware mode after closing a demo and open the next demo. There is a problem 
-with the re-init of the periphery C-library  in context of the isolates. Investigations are ongoing.
+**Known problems:**
+To avoid application crashes when using Dart periphery methods within an isolate, it’s essential to call `reuseTmpFileLibrary(true)` before any periphery method invocations.
+
+```
+reuseTmpFileLibrary(true);
+i2c = I2C(gI2C);
+sgp30 = SGP30(i2c);
+```
+
+Dart periphery temporarily stores a copy of the c-periphery library in the system’s temp directory. If an isolate attempts this initialization again without the reuseTmpFileLibrary(true) setting, it will cause the application to crash, with no opportunity to catch the error. 
+
+As an alternative solution, you can use
+`void loadLibFromFlutterAssetDir(bool load)`  to address this issue.
+For more details, refer to the documentation [here](https://github.com/pezi/dart_periphery?tab=readme-ov-file#flutter-pi).  
 
 **Starting**
 The isolate related code can be found here:

--- a/lib/flutter_internals.dart
+++ b/lib/flutter_internals.dart
@@ -1,13 +1,14 @@
 const Map<String,String> flutterInternals = 
 {
-  'frameworkVersion': '3.22.3',
+  'frameworkVersion': '3.24.4',
   'channel': 'stable',
   'repositoryUrl': 'https://github.com/flutter/flutter.git',
-  'frameworkRevision': 'b0850beeb25f6d5b10426284f506557f66181b36',
-  'frameworkCommitDate': '2024-07-16 21:43:41 -0700',
-  'engineRevision': '235db911ba279722f5e685f38b0ed30fa7e8570a',
-  'dartSdkVersion': '3.4.4',
-  'devToolsVersion': '2.34.3',
-  'flutterVersion': '3.22.3',
+  'frameworkRevision': '603104015dd692ea3403755b55d07813d5cf8965',
+  'frameworkCommitDate': '2024-10-24 08:01:25 -0700',
+  'engineRevision': 'db49896cf25ceabc44096d5f088d86414e05a7aa',
+  'dartSdkVersion': '3.5.4',
+  'devToolsVersion': '2.37.3',
+  'flutterVersion': '3.24.4',
+  'flutterRoot': '/Users/pezi/software/flutter/flutter_current'
 }
 ;

--- a/lib/isolates/isolate_bme280.dart
+++ b/lib/isolates/isolate_bme280.dart
@@ -49,8 +49,16 @@ class BME280isolate extends IsolateWrapper {
     if (!(initialData as bool)) {
       try {
         i2c.dispose();
-      } catch (e) {
-        // we can do nothing
+      } on Exception catch (e, s) {
+        if (kDebugMode) {
+          print('Exception details:\n $e');
+          print('Stack trace:\n $s');
+        }
+      } on Error catch (e, s) {
+        if (kDebugMode) {
+          print('Error details:\n $e');
+          print('Stack trace:\n $s');
+        }
       }
     }
     if (cmd == 'exit') {
@@ -72,7 +80,17 @@ class BME280isolate extends IsolateWrapper {
         i2c = I2C(gI2C);
         bme280 = BME280(i2c);
         return InitTaskResult(i2c.toJson(), getData());
-      } catch (e) {
+      } on Exception catch (e, s) {
+        if (kDebugMode) {
+          print('Exception details:\n $e');
+          print('Stack trace:\n $s');
+        }
+        return InitTaskResult.error(e.toString());
+      } on Error catch (e, s) {
+        if (kDebugMode) {
+          print('Error details:\n $e');
+          print('Stack trace:\n $s');
+        }
         return InitTaskResult.error(e.toString());
       }
     }
@@ -96,9 +114,16 @@ class BME280isolate extends IsolateWrapper {
       }
       ++counter;
       return MainTaskResult(false, m);
-    } catch (e) {
+    } on Exception catch (e, s) {
       if (kDebugMode) {
-        print('Sensor error: $e');
+        print('Exception details:\n $e');
+        print('Stack trace:\n $s');
+      }
+      return MainTaskResult.error(true, e.toString());
+    } on Error catch (e, s) {
+      if (kDebugMode) {
+        print('Error details:\n $e');
+        print('Stack trace:\n $s');
       }
       return MainTaskResult.error(true, e.toString());
     }

--- a/lib/isolates/isolate_bme280.dart
+++ b/lib/isolates/isolate_bme280.dart
@@ -12,6 +12,10 @@ import 'package:flutter/foundation.dart';
 import '../constants.dart';
 import 'isolate_helper.dart';
 
+// measurement pause in sec
+const int measurementPause = 2;
+
+/// Isolate to handle a BME280 sensor: temperature, humidity and pressure
 class BME280isolate extends IsolateWrapper {
   int counter = 1;
   late I2C i2c;
@@ -20,6 +24,7 @@ class BME280isolate extends IsolateWrapper {
   BME280isolate(super.isolateId, bool super.simulation);
   BME280isolate.empty() : super.empty();
 
+  /// Returns the sensor data as [Map].
   Map<String, dynamic> getData() {
     var result = bme280.getValues();
 
@@ -33,6 +38,7 @@ class BME280isolate extends IsolateWrapper {
     return values;
   }
 
+  /// Returns simulated sensor data.
   Map<String, dynamic> getSimulatedData() {
     var values = <String, dynamic>{};
     values['c'] = counter;
@@ -46,6 +52,7 @@ class BME280isolate extends IsolateWrapper {
   @override
   void processData(SendPort sendPort, Object data) {
     String cmd = data as String;
+    // real hardware in use?
     if (!(initialData as bool)) {
       try {
         i2c.dispose();
@@ -61,6 +68,8 @@ class BME280isolate extends IsolateWrapper {
         }
       }
     }
+
+    // handle program control flow
     if (cmd == 'exit') {
       exit(0);
     }
@@ -75,6 +84,7 @@ class BME280isolate extends IsolateWrapper {
       print('Isolate init task');
     }
 
+    // real hardware in use?
     if (!(initialData as bool)) {
       try {
         i2c = I2C(gI2C);
@@ -103,6 +113,7 @@ class BME280isolate extends IsolateWrapper {
     try {
       var m = <String, dynamic>{};
 
+      // real hardware in use?
       if (!(initialData as bool)) {
         m = getData();
       } else {
@@ -110,7 +121,7 @@ class BME280isolate extends IsolateWrapper {
       }
 
       if (counter != 0) {
-        await Future.delayed(const Duration(seconds: 2));
+        await Future.delayed(const Duration(seconds: measurementPause));
       }
       ++counter;
       return MainTaskResult(false, m);

--- a/lib/isolates/isolate_bme280.dart
+++ b/lib/isolates/isolate_bme280.dart
@@ -87,6 +87,7 @@ class BME280isolate extends IsolateWrapper {
     // real hardware in use?
     if (!(initialData as bool)) {
       try {
+        reuseTmpFileLibrary(true);
         i2c = I2C(gI2C);
         bme280 = BME280(i2c);
         return InitTaskResult(i2c.toJson(), getData());

--- a/lib/isolates/isolate_bme680.dart
+++ b/lib/isolates/isolate_bme680.dart
@@ -87,6 +87,7 @@ class BME680isolate extends IsolateWrapper {
 
     if (!(initialData as bool)) {
       try {
+        reuseTmpFileLibrary(true);
         i2c = I2C(gI2C);
         bme680 = BME680(i2c);
         return InitTaskResult(i2c.toJson(), getData());

--- a/lib/isolates/isolate_cozir.dart
+++ b/lib/isolates/isolate_cozir.dart
@@ -98,6 +98,7 @@ class CozIRisolate extends IsolateWrapper {
 
     if (!(initialData as bool)) {
       try {
+        reuseTmpFileLibrary(true);
         serial = Serial('/dev/serial0', Baudrate.b9600);
         if (kDebugMode) {
           print('Serial interface info: ${serial.getSerialInfo()}');

--- a/lib/isolates/isolate_factory.dart
+++ b/lib/isolates/isolate_factory.dart
@@ -11,7 +11,7 @@ import 'isolate_leds.dart';
 import 'isolate_sgp30.dart';
 import 'isolate_sht31.dart';
 
-/// Constructs a class by name
+/// Constructs a class by name. This construction enables an
 class IsolateClassFactory {
   static final Map<String,
       IsolateWrapper Function(String isolateId, Object data)> _constructors = {

--- a/lib/isolates/isolate_helper.dart
+++ b/lib/isolates/isolate_helper.dart
@@ -13,8 +13,8 @@ import 'isolate_factory.dart';
 
 /// generic task result
 abstract class TaskResult {
-  bool error;
-  Map<String, dynamic>? data;
+  final bool error;
+  final Map<String, dynamic>? data;
   TaskResult(this.error, [this.data]);
 }
 
@@ -22,7 +22,8 @@ abstract class TaskResult {
 class InitTaskResult extends TaskResult {
   String json;
 
-  /// Return value of the init task, [error] signals an error, [json] represents the device configuration and the optional user [data].
+  /// Return value of the init task, [error] signals an error, [json] represents
+  /// the device configuration and the optional user [data].
   InitTaskResult(this.json, [Map<String, dynamic>? data]) : super(false, data);
 
   InitTaskResult.error(String error)
@@ -37,7 +38,8 @@ class InitTaskResult extends TaskResult {
 class MainTaskResult extends TaskResult {
   bool exit;
 
-  /// Return value of a main task, [error] signals an error, [exit] to quit the main loop and the optional user [data].
+  /// Return value of a main task, [error] signals an error, [exit] to quit the
+  /// main loop and the optional user [data].
   MainTaskResult(this.exit, [Map<String, dynamic>? data]) : super(false, data);
   MainTaskResult.error(this.exit, String error)
       : super(true, IsolateError(TaskMethod.init, error).toJson());
@@ -89,7 +91,7 @@ abstract class IsolateWrapper {
     throw UnimplementedError("exit() - not implemented");
   }
 
-  /// Process [data] from the isolate initiator.
+  /// Processes [data] from the isolate initiator.
   /// Do not perform long lasting operations in the method
   /// which blocks the main task!
   void processData(SendPort sendPort, Object data) {}
@@ -123,12 +125,12 @@ class IsolateError {
       {'method': method.index, 'milliSecs': timestamp, "error": error};
 }
 
-/// Run an [IsolateWrapper] based class as an isolate
+/// Runs an [IsolateWrapper] based class as an isolate
 class IsolateHelper {
-  IsolateWrapper className;
-  TaskIteration iterationTask;
-  Object initialData;
-  String isolateId;
+  final IsolateWrapper className;
+  final TaskIteration iterationTask;
+  final Object initialData;
+  final String isolateId;
 
   Isolate? isolate;
   String? json;
@@ -230,6 +232,7 @@ class IsolateHelper {
 
       // wait only for commands from isolate initiator
       if (classInfo['listeningMode'] as bool) {
+        // infinite loop
         while (true) {
           await Future.delayed(const Duration(days: 365));
         }

--- a/lib/isolates/isolate_leds.dart
+++ b/lib/isolates/isolate_leds.dart
@@ -57,6 +57,7 @@ class LedsIsolate extends IsolateWrapper {
 
     if (!(initialData as bool)) {
       try {
+        reuseTmpFileLibrary(true);
         gpioMap[LedColor.red] = GPIO(18, GPIOdirection.gpioDirOut);
         gpioMap[LedColor.yellow] = GPIO(16, GPIOdirection.gpioDirOut);
         gpioMap[LedColor.green] = GPIO(5, GPIOdirection.gpioDirOut);

--- a/lib/isolates/isolate_sgp30.dart
+++ b/lib/isolates/isolate_sgp30.dart
@@ -56,6 +56,7 @@ class SGP30isolate extends IsolateWrapper {
 
     if (!(initialData as bool)) {
       try {
+        reuseTmpFileLibrary(true);
         i2c = I2C(gI2C);
         sgp30 = SGP30(i2c);
         return InitTaskResult(i2c.toJson(), getData());

--- a/lib/tab/configuration_tab.dart
+++ b/lib/tab/configuration_tab.dart
@@ -65,7 +65,7 @@ class _ConfigurationTabState extends State<ConfigurationTab> {
       ),
       CheckboxListTile(
         controlAffinity: ListTileControlAffinity.leading,
-        title: const Text("Demo mode"),
+        title: const Text("Simulation mode"),
         value: gSimulateSensor,
         onChanged: (bool? value) {
           setState(() {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <screen_retriever/screen_retriever_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
-  screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  screen_retriever
+  screen_retriever_linux
   url_launcher_linux
   window_manager
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,12 @@
 import FlutterMacOS
 import Foundation
 
-import screen_retriever
+import screen_retriever_macos
 import url_launcher_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,18 +77,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -98,18 +98,18 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.0.0"
   flutter_reorderable_grid_view:
     dependency: "direct main"
     description:
       name: flutter_reorderable_grid_view
-      sha256: "40abcc5bff228ebff119326502e7357ee6399956b60b80b17385e9770b7458c0"
+      sha256: "93a2b9e279bf40b9333428a67e70e520ca1528554984eb6f6304538400897e64"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.3.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -128,22 +128,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -156,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -172,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   multiple_stream_builder:
     dependency: "direct main"
     description:
@@ -204,10 +212,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -228,10 +236,42 @@ packages:
     dependency: transitive
     description:
       name: screen_retriever
-      sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.9"
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -281,26 +321,26 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "94d8ad05f44c6d4e2ffe5567ab4d741b82d62e3c8e288cc1fcea45965edf47c9"
+      sha256: "0dea215895a4d254401730ca0ba8204b29109a34a99fb06ae559a2b60988d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.8"
+    version: "6.3.13"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -313,18 +353,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.0"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -337,18 +377,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   vector_math:
     dependency: transitive
     description:
@@ -361,26 +401,26 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.0"
   window_manager:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "8699323b30da4cdbe2aa2e7c9de567a6abd8a97d9a5c850a3c86dcd0b34bbfbf"
+      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.9"
+    version: "0.4.3"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "95d8027db36a0e52caf55680f91e33ea6aa12a3ce608c90b06f4e429a21067ac"
+      sha256: "94d8ad05f44c6d4e2ffe5567ab4d741b82d62e3c8e288cc1fcea45965edf47c9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.5"
+    version: "6.3.8"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -345,10 +345,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.1
 
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,11 +38,13 @@ dependencies:
   async: ^2.11.0
   intl: ^0.19.0
   dart_periphery: ^0.9.6
+#  dart_periphery: 
+#    path: ../dart_periphery
   flutter_reorderable_grid_view: ^5.0.1
   convex_bottom_bar: ^3.2.0
   url_launcher: ^6.2.5
   multiple_stream_builder: ^3.0.2
-  window_manager: ^0.3.8
+  window_manager: ^0.4.3
 
 dev_dependencies:
   flutter_test:
@@ -53,7 +55,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,13 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <screen_retriever/screen_retriever_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  ScreenRetrieverPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  screen_retriever
+  screen_retriever_windows
   url_launcher_windows
   window_manager
 )


### PR DESCRIPTION
Dart periphery temporarily stores a copy of the c-periphery library in the system’s temp directory. If an isolate attempts this initialization again without the `reuseTmpFileLibrary(true)` setting, it will cause the application to crash, with no opportunity to catch the error.